### PR TITLE
Fix: remove hasInitialDeviceList() call that throws UnsupportedMethodException

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ pluginName=YALI
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 sinceBuild=253.28294.334
-pluginVersion=26.04.12.0
+pluginVersion=26.05.25.0
 # Use the latest of Android plugin versionAdd commentMore actions
 # see https://github.com/JetBrains/intellij-platform-gradle-plugin/releases
 # androidPluginVersion=251.25410.109

--- a/src/main/kotlin/com/github/grishberg/androidstudio/plugins/AdbWrapper.kt
+++ b/src/main/kotlin/com/github/grishberg/androidstudio/plugins/AdbWrapper.kt
@@ -17,7 +17,7 @@ class AdbWrapperImpl(project: Project) : AdbWrapper {
             return false
         }
 
-        return androidBridge.isConnected && androidBridge.hasInitialDeviceList()
+        return androidBridge.isConnected
     }
 
     override fun connectedDevices(): List<IDevice> {


### PR DESCRIPTION
`AndroidDebugBridge.hasInitialDeviceList()` кидает `UnsupportedMethodException` в новых версиях Android Studio (из-за `AdbLibAndroidDebugBridge`-совместимости). Это ломало `isReady()` и устройства не загружались.

Fix: убрать вызов `hasInitialDeviceList()`, оставив только проверку `isConnected`.
